### PR TITLE
API 19 support, removed conflicted string app_name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 30
+
     defaultConfig {
         applicationId "com.jsramraj.countryflags"
-        minSdkVersion 24
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -21,10 +21,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     compile project(path: ':flags')
 }

--- a/app/src/main/java/com/jsramraj/countryflags/MainActivity.java
+++ b/app/src/main/java/com/jsramraj/countryflags/MainActivity.java
@@ -1,18 +1,14 @@
 package com.jsramraj.countryflags;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ImageView;
 import android.widget.ListView;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.jsramraj.flags.FlagDrawableProvider;
 import com.jsramraj.flags.Flags;
@@ -25,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 
 public class MainActivity extends AppCompatActivity implements FlagSelectionObserver {
@@ -55,7 +52,7 @@ public class MainActivity extends AppCompatActivity implements FlagSelectionObse
                 .setTileHeight(220)
                 .build();
 
-        ((ImageView)findViewById(R.id.selectedCountry)).setImageDrawable(flagDrawableProvider.forCountry("US"));
+        ((ImageView) findViewById(R.id.selectedCountry)).setImageDrawable(flagDrawableProvider.forCountry("US"));
 
         final ArrayList<Country> countries = new ArrayList<>();
         String countryDataJson = readJSONFromAsset(this, "country_list.json");
@@ -69,12 +66,13 @@ public class MainActivity extends AppCompatActivity implements FlagSelectionObse
             }
 
             //sort the countries by country name alphabetically
-            countries.sort(new Comparator<Country>() {
-                @Override
-                public int compare(Country c1, Country c2) {
-                    return c1.getName().compareToIgnoreCase(c2.getName());
-                }
-            });
+            Collections.sort(
+                    countries, new Comparator<Country>() {
+                        @Override
+                        public int compare(Country c1, Country c2) {
+                            return c1.getName().compareToIgnoreCase(c2.getName());
+                        }
+                    });
             CountryAdapter adapter = new CountryAdapter(this, countries);
             ListView countryListView = findViewById(R.id.country_list_view);
             countryListView.setAdapter(adapter);
@@ -99,6 +97,6 @@ public class MainActivity extends AppCompatActivity implements FlagSelectionObse
 
     @Override
     public void onFlagSelected(String countryCode) {
-        ((ImageView)findViewById(R.id.selectedCountry)).setImageDrawable(flagDrawableProvider.forCountry(countryCode));
+        ((ImageView) findViewById(R.id.selectedCountry)).setImageDrawable(flagDrawableProvider.forCountry(countryCode));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/flags/build.gradle
+++ b/flags/build.gradle
@@ -1,13 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
-
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -31,10 +29,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito:mockito-core:3.1.0'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/flags/src/main/res/values/strings.xml
+++ b/flags/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Flags</string>
-</resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 08 06:18:44 IST 2020
+#Mon Nov 30 14:41:18 EET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
I don't know why the min API ver. is 24 there is no reason for that, it forces the apps to be with the same min API level support.
Also the unnecessary app_name string from the library makes conflicts whit my app, I tried to override that by it cause other issues.